### PR TITLE
Remove underline on buttons

### DIFF
--- a/app/routes/loaders.tsx
+++ b/app/routes/loaders.tsx
@@ -43,7 +43,7 @@ export default function BlockingAndStreaming() {
             onto a link in TanStack Start by default.
           </p>
 
-          <nav className="flex flex-col space-y-4 mb-4">
+          <nav className="flex flex-col space-y-4 mb-4 not-prose">
             <Button asChild>
               <Link
                 to="/loaders/ensure"


### PR DESCRIPTION
Remove underline styling on buttons, since it can make the text harder to read (for instance, it looks like we’re talking about a variable called `await_queryClient`)