### PR TITLE
Make `/react-query` use `useQuery` instead of `useSuspenseQuery`

### DIFF
--- a/src/routes/react-query.tsx
+++ b/src/routes/react-query.tsx
@@ -14,6 +14,10 @@ export const Route = createFileRoute('/react-query')({
       ...convexQuery(api.messages.isSimulatingTraffic, {}),
       gcTime: 2000,
     })
+    context.queryClient.prefetchQuery({
+      ...convexQuery(api.messages.listMessages, {}),
+      gcTime: 2000,
+    })
   },
 })
 

--- a/src/routes/react-query.tsx
+++ b/src/routes/react-query.tsx
@@ -61,7 +61,7 @@ export default function ReactQuery() {
             </Button>{' '}
             to see these updates pushed live.{' '}
           </p>
-          <Chat useSuspense={true} />
+          <Chat useSuspense={false} />
         </div>
         <div>
           <CodeSample


### PR DESCRIPTION
The code on `/react-query` uses `useQuery`, not `useSuspenseQuery`, so we should actually use `useQuery` + `prefetchQuery` on the page.