### PR TITLE
Fix npm create command for npm 11 compatibility

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -93,7 +93,7 @@ export default function LandingPage() {
           <p className="text-sm font-bold mb-2">Or run:</p>
           <p className="text-lg font-light">
             <code className="bg-slate-700 block px-4 py-2 rounded-md border border-slate-600">
-              npx create-convex@latest  -t tanstack-start
+              npx create-convex@latest -t tanstack-start
             </code>
           </p>
         </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -93,7 +93,7 @@ export default function LandingPage() {
           <p className="text-sm font-bold mb-2">Or run:</p>
           <p className="text-lg font-light">
             <code className="bg-slate-700 block px-4 py-2 rounded-md border border-slate-600">
-              npm create convex@latest -- -t tanstack-start
+              npx create-convex@latest  -t tanstack-start
             </code>
           </p>
         </div>


### PR DESCRIPTION
npm 11 broke passing through config flags with npm create.
Replaced 'npm create convex@latest --' with 'npx create-convex@latest'
and 'npm create convex --' with 'npx create-convex'.